### PR TITLE
Fix upstream ruby-trello dependency version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.1.2
+- Fix upstream ruby-trello dependency version
+
 # 0.1.1
 - Fix incorrect installation instructions
 

--- a/lib/trello/list2card/version.rb
+++ b/lib/trello/list2card/version.rb
@@ -1,5 +1,5 @@
 module Trello
     class List2Card
-        VERSION = '0.1.1'
+        VERSION = '0.1.2'
     end
 end

--- a/trello-list2card.gemspec
+++ b/trello-list2card.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'ruby-trello', '~> 1.5'
+  spec.add_dependency 'ruby-trello', '~> 2.2'
   spec.add_dependency 'toml-rb', '~> 0.3'
 end


### PR DESCRIPTION
The latest version of activemodel (6.0.2) is not compactible with ruby-trello (1.5) and activemodel is not pinned in ruby-trello. In this PR the ruby-trello version changed to the current latest (2.2.0), which seems to work.

**Please note the ruby-trello 2.0 is dropping support for Ruby 1.9.**

After installing this tool from the published ruby gem and running it in a ruby docker container, it fails the following way when the execution reaches `card.save`.

To reproduce the issue I also printed the exception and re-built the gem locally:

```
$ docker run -it --name trello-list2card --mount type=bind,source="$(pwd)",target=/src ruby bash
root@a732b6491343:/# cd src
root@a732b6491343:/src# gem build trello-list2card.gemspec
  Successfully built RubyGem
  Name: trello-list2card
  Version: 0.1.1
  File: trello-list2card-0.1.1.gem

root@a732b6491343:/src# gem install trello-list2card-0.1.1.gem
Fetching http-accept-1.7.0.gem
Fetching unf-0.1.4.gem
Fetching citrus-3.0.2.gem
Fetching unf_ext-0.0.7.6.gem
Fetching domain_name-0.5.20190701.gem
Fetching mime-types-data-3.2019.1009.gem
Fetching http-cookie-1.0.3.gem
Fetching toml-rb-0.3.15.gem
Fetching mime-types-3.3.gem
Fetching public_suffix-4.0.1.gem
Fetching oauth-0.5.4.gem
Fetching netrc-0.11.0.gem
Fetching addressable-2.7.0.gem
Fetching concurrent-ruby-1.1.5.gem
Fetching i18n-1.7.0.gem
Fetching thread_safe-0.3.6.gem
Fetching rest-client-2.1.0.gem
Fetching activesupport-6.0.2.gem
Fetching ruby-trello-1.6.0.gem
Fetching tzinfo-1.2.5.gem
Fetching activemodel-6.0.2.gem
Fetching zeitwerk-2.2.2.gem
Successfully installed citrus-3.0.2
Successfully installed toml-rb-0.3.15
Successfully installed http-accept-1.7.0
Building native extensions. This could take a while...
Successfully installed unf_ext-0.0.7.6
Successfully installed unf-0.1.4
Successfully installed domain_name-0.5.20190701
Successfully installed http-cookie-1.0.3
Successfully installed mime-types-data-3.2019.1009
Successfully installed mime-types-3.3
Successfully installed netrc-0.11.0
Successfully installed rest-client-2.1.0
Successfully installed oauth-0.5.4
Successfully installed public_suffix-4.0.1
Successfully installed addressable-2.7.0
Successfully installed concurrent-ruby-1.1.5

HEADS UP! i18n 1.1 changed fallbacks to exclude default locale.
But that may break your application.

Please check your Rails app for 'config.i18n.fallbacks = true'.
If you're using I18n (>= 1.1.0) and Rails (< 5.2.2), this should be
'config.i18n.fallbacks = [I18n.default_locale]'.
If not, fallbacks will be broken in your app by I18n 1.1.x.
For more info see:
https://github.com/svenfuchs/i18n/releases/tag/v1.1.0

Successfully installed i18n-1.7.0
Successfully installed thread_safe-0.3.6
Successfully installed tzinfo-1.2.5
Successfully installed zeitwerk-2.2.2
Successfully installed activesupport-6.0.2
Successfully installed activemodel-6.0.2
Successfully installed ruby-trello-1.6.0
Successfully installed trello-list2card-0.1.1
23 gems installed

root@a732b6491343:/src# list2card -c etc/config.toml
I, [2019-12-15T18:29:33.928873 #52]  INFO -- : Loaded list xxx
I, [2019-12-15T18:29:33.929066 #52]  INFO -- : 6 card(s) to process
D, [2019-12-15T18:29:33.929152 #52] DEBUG -- : message: '6 tasks completed

E, [2019-12-15T18:59:40.803887 #123] ERROR -- : undefined method `changed?' for "xxx":String (NoMethodError)
/usr/local/bundle/gems/activemodel-6.0.2/lib/active_model/attribute_mutation_tracker.rb:76:in `attribute_changed?'
/usr/local/bundle/gems/activemodel-6.0.2/lib/active_model/attribute_mutation_tracker.rb:46:in `changed?'
/usr/local/bundle/gems/activemodel-6.0.2/lib/active_model/attribute_mutation_tracker.rb:36:in `change_to_attribute'
/usr/local/bundle/gems/activemodel-6.0.2/lib/active_model/attribute_mutation_tracker.rb:29:in `block in changes'
/usr/local/bundle/gems/activemodel-6.0.2/lib/active_model/attribute_mutation_tracker.rb:28:in `each'
/usr/local/bundle/gems/activemodel-6.0.2/lib/active_model/attribute_mutation_tracker.rb:28:in `each_with_object'
/usr/local/bundle/gems/activemodel-6.0.2/lib/active_model/attribute_mutation_tracker.rb:28:in `changes'
/usr/local/bundle/gems/activemodel-6.0.2/lib/active_model/dirty.rb:218:in `changes'
/usr/local/bundle/gems/ruby-trello-1.6.0/lib/trello/card.rb:275:in `update!'
/usr/local/bundle/gems/ruby-trello-1.6.0/lib/trello/card.rb:248:in `save'
/usr/local/bundle/gems/trello-list2card-0.1.1/lib/trello/list2card.rb:164:in `block in do_run'
/usr/local/bundle/gems/ruby-trello-1.6.0/lib/trello/association_proxy.rb:23:in `each'
/usr/local/bundle/gems/ruby-trello-1.6.0/lib/trello/association_proxy.rb:23:in `method_missing'
/usr/local/bundle/gems/trello-list2card-0.1.1/lib/trello/list2card.rb:158:in `do_run'
/usr/local/bundle/gems/trello-list2card-0.1.1/bin/list2card:56:in `<top (required)>'
/usr/local/bundle/bin/list2card:23:in `load'
/usr/local/bundle/bin/list2card:23:in `<main>'
E, [2019-12-15T18:59:40.809341 #123] ERROR -- : Failed to archive 'xxx'
I, [2019-12-15T18:59:40.809426 #123]  INFO -- : Done
...

```
